### PR TITLE
Basic support for broadcast messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,25 @@ docker compose exec app python scripts/talk_to_process_manager.py
 ```
 
 Take the servers down with `docker compose down`
+
+### Working with Kafka
+
+Due to the complexities of containerising Kafka it is not possible to use the standard
+Docker Compose setup. Instead when working with functionality that requires Kafka it is
+necessary to run the individual components manually.
+
+1. Start the drunc shell:
+   `poetry run drunc-unified-shell --log-level debug ./data/process-manager-pocket-kafka.json`
+
+1. Start Kafka - See [Running drunc with pocket kafka].
+
+1. Start the application server:
+   `poetry run python manage.py runserver`
+
+1. Start the Kafka consumer:
+   `poetry run python scripts/kafka_consumer.py`
+
+From here you should be able to see broadcast messages displayed at the top of the index
+page on every refresh.
+
+[Running drunc with pocket kafka]: https://github.com/DUNE-DAQ/drunc/wiki/Running-drunc-with-pocket-kafka

--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ Due to the complexities of containerising Kafka it is not possible to use the st
 Docker Compose setup. Instead when working with functionality that requires Kafka it is
 necessary to run the individual components manually.
 
+1. Start Kafka - See [Running drunc with pocket kafka].
+
 1. Start the drunc shell:
    `poetry run drunc-unified-shell --log-level debug ./data/process-manager-pocket-kafka.json`
-
-1. Start Kafka - See [Running drunc with pocket kafka].
 
 1. Start the application server:
    `poetry run python manage.py runserver`

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,5 @@
+# Data files
+
+## process-manager-pocket-kafka.json
+
+Process manager configuration file for use in local development with Kafka.

--- a/data/process-manager-pocket-kafka.json
+++ b/data/process-manager-pocket-kafka.json
@@ -1,0 +1,13 @@
+{
+    "type": "ssh",
+    "name": "SSHProcessManager",
+    "command_address": "0.0.0.0:10054",
+    "authoriser": {
+        "type": "dummy"
+    },
+    "broadcaster": {
+        "type": "kafka",
+        "kafka_address": "127.0.0.1:30092",
+        "publish_timeout": 2
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
     volumes:
       - .:/usr/src/app
       - db:/usr/src/app/db
+    environment:
+      - PROCESS_MANAGER_URL=drunc:10054
   drunc:
     build: ./drunc_docker_service/
     command:

--- a/dune_processes/settings/settings.py
+++ b/dune_processes/settings/settings.py
@@ -9,6 +9,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.1/ref/settings/
 """
 
+import os
 from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -133,3 +134,5 @@ AUTH_USER_MODEL = "main.User"
 
 INSTALLED_APPS += ["django_bootstrap5"]
 DJANGO_TABLES2_TEMPLATE = "django_tables2/bootstrap5.html"
+
+PROCESS_MANAGER_URL = os.getenv("PROCESS_MANAGER_URL", "localhost:10054")

--- a/main/templates/main/index.html
+++ b/main/templates/main/index.html
@@ -4,9 +4,21 @@
 {% block title %}Home{% endblock title %}
 
 {% block content %}
+
 <div class="col">
+  {% if messages %}
+  <h2>Messages</h2>
+  <div style="white-space: pre-wrap;">
+    {% for message in messages %}
+    {{ message }}
+    {% endfor %}
+  </div>
+  <hr class="solid">
+  {% endif %}
+
   <a href="{% url 'main:boot_process' %}" class="btn btn-primary">Boot</a>
   {% render_table table %}
 </div>
+
 
 {% endblock content %}

--- a/main/urls.py
+++ b/main/urls.py
@@ -12,4 +12,5 @@ urlpatterns = [
     path("flush/<uuid:uuid>", views.flush_process, name="flush"),
     path("logs/<uuid:uuid>", views.logs, name="logs"),
     path("boot_process/", views.BootProcessView.as_view(), name="boot_process"),
+    path("message/", views.deposit_message, name="message"),
 ]

--- a/main/views.py
+++ b/main/views.py
@@ -6,6 +6,7 @@ from enum import Enum
 from http import HTTPStatus
 
 import django_tables2
+from django.conf import settings
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import reverse, reverse_lazy
@@ -34,7 +35,9 @@ MESSAGES: list[str] = []
 def get_process_manager_driver() -> ProcessManagerDriver:
     """Get a ProcessManagerDriver instance."""
     token = create_dummy_token_from_uname()
-    return ProcessManagerDriver("drunc:10054", token=token, aio_channel=True)
+    return ProcessManagerDriver(
+        settings.PROCESS_MANAGER_URL, token=token, aio_channel=True
+    )
 
 
 async def get_session_info() -> ProcessInstanceList:

--- a/main/views.py
+++ b/main/views.py
@@ -27,7 +27,7 @@ from .forms import BootProcessForm
 from .tables import ProcessTable
 
 # extreme hackiness suitable only for demonstration purposes
-# will replace this with per-user session storage - once we've added auth
+# TODO: replace this with per-user session storage - once we've added auth
 MESSAGES: list[str] = []
 """Broadcast messages to display to the user."""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ module = "tests.*"
 disallow_untyped_defs = false
 
 [[tool.mypy.overrides]]
-module = ["druncschema.*", "drunc.*", "django_tables2.*"]
+module = ["druncschema.*", "drunc.*", "django_tables2.*", "kafka.*"]
 ignore_missing_imports = true
 
 [tool.django-stubs]

--- a/scripts/kafka_consumer.py
+++ b/scripts/kafka_consumer.py
@@ -1,0 +1,33 @@
+"""Example client that consumes messages from Kafka and sends them to the web app."""
+
+import os
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from druncschema.broadcast_pb2 import BroadcastMessage
+from kafka import KafkaConsumer
+
+KAFKA_URL = os.getenv("KAFKA_URL", "127.0.0.1:30092")
+SERVER_URL = os.getenv("SERVER_URL", "http://localhost:8000")
+
+
+def main() -> None:
+    """Listen for Kafka messages and process them indefinitely."""
+    consumer = KafkaConsumer(bootstrap_servers=[KAFKA_URL])
+    consumer.subscribe(pattern="control.*.process_manager")
+
+    print("Listening for messages from Kafka.")
+    while True:
+        for messages in consumer.poll(timeout_ms=500).values():
+            for message in messages:
+                print(f"Message received: {message}")
+                bm = BroadcastMessage()
+                bm.ParseFromString(message.value)
+
+                data = urlencode(dict(message=bm.data.value))
+                request = Request(f"{SERVER_URL}/message/", data=data.encode())
+                urlopen(request)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Description

Provides the simplest possible implementation for broadcast messages that I could come up with. A more sophisticated version will be possible after #7 is completed. Adds:

- A web endpoint where messages can be deposited - currently saved into a global variable but will change to user sessions (i.e. databese) once we have users...
- A script - `kafka_consumer.py` - that listens for messages send by Kafka and uploads to the web endpoint.
- Basic display of messages on the index page.
- Some supporting configuration changes.

Working with Kafka is a bit fiddly so let me know how you get on with the instructions added in the README.

No tests yet as I don't they're useful for something so hacky.

I'm not aiming to have this merged by the end of the day so take your time.

Fixes #11 and #10 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [X] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [X] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
