### PR TITLE
Assert redirects

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,8 @@
         88
     ],
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+    "python.testing.pytestEnabled": true,
+    "python.testing.pytestArgs": [
+        "--no-cov"
+    ]
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,3 +7,6 @@ coverage:
     patch:
       default:
         informational: true
+
+ignore:
+  - dune_processes/settings/_production.py

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -67,11 +67,8 @@ class TestIndexView(LoginRequiredTest):
 class TestLogsView(LoginRequiredTest):
     """Tests for the logs view."""
 
-    @classmethod
-    def setup_class(cls):
-        """Set up the endpoint for the tests."""
-        cls.uuid = uuid4()
-        cls.endpoint = reverse("main:logs", kwargs=dict(uuid=cls.uuid))
+    uuid = uuid4()
+    endpoint = reverse("main:logs", kwargs=dict(uuid=uuid))
 
     def test_logs_view_authenticated(self, auth_client, mocker):
         """Test the logs view for an authenticated user."""

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 import pytest
 from django.urls import reverse
-from pytest_django.asserts import assertContains, assertTemplateUsed
+from pytest_django.asserts import assertContains, assertRedirects, assertTemplateUsed
 
 from main.views import ProcessAction
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 import pytest
 from django.urls import reverse
-from pytest_django.asserts import assertContains, assertRedirects, assertTemplateUsed
+from pytest_django.asserts import assertContains, assertTemplateUsed
 
 from main.views import ProcessAction
 
@@ -104,10 +104,11 @@ class TestProcessRestartView(ProcessActionsTest):
     action = ProcessAction.RESTART
 
 
-class TestBootProcess:
+class TestBootProcess(LoginRequiredTest):
     """Grouping the tests for the BootProcess view."""
 
     template_name = "main/boot_process.html"
+    endpoint = reverse("main:boot_process")
 
     def test_boot_process_get(self, auth_client):
         """Test the GET request for the BootProcess view."""
@@ -117,12 +118,6 @@ class TestBootProcess:
 
         assert "form" in response.context
         assertContains(response, f'form action="{reverse("main:boot_process")}"')
-
-    def test_boot_process_get_anon(self, client):
-        """Test the GET request for the BootProcess view with an anonymous client."""
-        response = client.get(reverse("main:boot_process"))
-        assert response.status_code == HTTPStatus.FOUND
-        assertRedirects(response, "/accounts/login/?next=/boot_process/")
 
     def test_boot_process_post_invalid(self, auth_client):
         """Test the POST request for the BootProcess view with invalid data."""

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -18,9 +18,7 @@ class LoginRequiredTest:
         response = client.get(self.endpoint)
         assert response.status_code == HTTPStatus.FOUND
 
-        # AssertRedirects try to match the exact URL, but the URL may contain a query
-        # string. So, we just check the start of the URL.
-        assert response.url.startswith(reverse("main:login"))
+        assertRedirects(response, reverse("main:login") + f"?next={self.endpoint}")
 
 
 class ProcessActionsTest(LoginRequiredTest):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -65,22 +65,23 @@ class TestLogsView(LoginRequiredTest):
         assert "log_text" in response.context
 
 
-def test_process_flush(client, auth_client, mocker):
-    """Test the process_flush view."""
-    mock = mocker.patch("main.views._process_call")
+class TestProcessFlushView(LoginRequiredTest):
+    """Tests for the process flush view."""
 
-    uuid = uuid4()
+    @classmethod
+    def setup_class(cls):
+        """Set up the endpoint for the tests."""
+        cls.uuid = uuid4()
+        cls.endpoint = reverse("main:flush", kwargs=dict(uuid=cls.uuid))
 
-    # Test with an anonymous client.
-    response = client.get(reverse("main:flush", kwargs=dict(uuid=uuid)))
-    assert response.status_code == HTTPStatus.FOUND
-    assertRedirects(response, f"/accounts/login/?next=/flush/{uuid}")
+    def test_process_flush_view_authenticated(self, auth_client, mocker):
+        """Test the process flush view for an authenticated user."""
+        mock = mocker.patch("main.views._process_call")
+        response = auth_client.get(self.endpoint)
+        assert response.status_code == HTTPStatus.FOUND
+        assert response.url == reverse("main:index")
 
-    # Test with an authenticated client.
-    response = auth_client.get(reverse("main:flush", kwargs=dict(uuid=uuid)))
-    assert response.status_code == HTTPStatus.FOUND
-    assert response.url == reverse("main:index")
-    mock.assert_called_once_with(str(uuid), ProcessAction.FLUSH)
+        mock.assert_called_once_with(str(self.uuid), ProcessAction.FLUSH)
 
 
 class TestBootProcess:


### PR DESCRIPTION
# Description

Adds base test classes - and then actual test classes - to assert the page redirection when visiting views that require authentication. 

Fixes #69 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [x] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
