### PR TITLE
Configure codecov to show coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: poetry install
 
       - name: Run tests
-        run: poetry run pytest
+        run: poetry run pytest --cov-report=xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,10 @@ jobs:
 
       - name: Run tests
         run: poetry run pytest
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <!-- markdownlint-disable MD041 -->
 [![GitHub](https://img.shields.io/github/license/ImperialCollegeLondon/dune_processes)](https://raw.githubusercontent.com/ImperialCollegeLondon/dune_processes/main/LICENCE.txt)
 [![Test and build](https://github.com/ImperialCollegeLondon/dune_processes/actions/workflows/ci.yml/badge.svg)](https://github.com/ImperialCollegeLondon/dune_processes/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/ImperialCollegeLondon/dune_processes/graph/badge.svg?token=PG0WTYF8EY)](https://codecov.io/gh/ImperialCollegeLondon/dune_processes)
 
 # DUNE processes web interface
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!-- markdownlint-disable MD041 -->
-[![GitHub](https://img.shields.io/github/license/ImperialCollegeLondon/dune_processes)](https://raw.githubusercontent.com/ImperialCollegeLondon/dune_processes/main/LICENCE.txt)
+[![GitHub](https://img.shields.io/github/license/ImperialCollegeLondon/dune_processes)](https://raw.githubusercontent.com/ImperialCollegeLondon/dune_processes/main/LICENSE)
 [![Test and build](https://github.com/ImperialCollegeLondon/dune_processes/actions/workflows/ci.yml/badge.svg)](https://github.com/ImperialCollegeLondon/dune_processes/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/ImperialCollegeLondon/dune_processes/graph/badge.svg?token=PG0WTYF8EY)](https://codecov.io/gh/ImperialCollegeLondon/dune_processes)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<!-- markdownlint-disable MD041 -->
+[![GitHub](https://img.shields.io/github/license/ImperialCollegeLondon/dune_processes)](https://raw.githubusercontent.com/ImperialCollegeLondon/dune_processes/main/LICENCE.txt)
+[![Test and build](https://github.com/ImperialCollegeLondon/dune_processes/actions/workflows/ci.yml/badge.svg)](https://github.com/ImperialCollegeLondon/dune_processes/actions/workflows/ci.yml)
+
 # DUNE processes web interface
 
 This repo defines the web interface for the DUNE Process Manager.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# dune_processes
+# DUNE processes web interface
 
-This repo defines the web app for the Dune Process Manager web interface.
+This repo defines the web interface for the DUNE Process Manager.
 
 ## For developers
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+# Don't fail CI if coverage drops
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
I've performed all the necessary configuration on codecov.io and in the repo settings, so that coverage info can be uploaded. This also means that the codecov app will notify us about missing coverage in PRs.

Summary:

- Configure codecov to only warn about missing coverage without making the CI fail
- Add a workflow to upload coverage
- Add a badge displaying coverage to readme (along with a couple of others)

Closes #78.
