### PR TITLE
Add bulk operations for processes

### DIFF
--- a/main/tables.py
+++ b/main/tables.py
@@ -33,6 +33,4 @@ class ProcessTable(tables.Table):
     status_code = tables.Column(verbose_name="Status Code")
     exit_code = tables.Column(verbose_name="Exit Code")
     logs = tables.TemplateColumn(logs_column_template, verbose_name="Logs")
-    restart = tables.TemplateColumn(restart_column_template, verbose_name="Restart")
-    flush = tables.TemplateColumn(flush_column_template, verbose_name="Flush")
-    kill = tables.TemplateColumn(kill_column_template, verbose_name="Kill")
+    select = tables.CheckBoxColumn(accessor="uuid", verbose_name="Select")

--- a/main/templates/main/index.html
+++ b/main/templates/main/index.html
@@ -5,8 +5,14 @@
 
 {% block content %}
 <div class="col">
-  <a href="{% url 'main:boot_process' %}" class="btn btn-primary">Boot</a>
-  {% render_table table %}
+  <form method="post", action="{% url 'main:process_action' %}">
+    {% csrf_token %}
+    <a href="{% url 'main:boot_process' %}" class="btn btn-primary">Boot</a>
+    <input type="submit" value="Restart" class="btn btn-success", name="action">
+    <input type="submit" value="Flush" class="btn btn-warning", name="action">
+    <input type="submit" value="Kill" class="btn btn-danger", name="action">
+    {% render_table table %}
+  </form>
 </div>
 
 {% endblock content %}

--- a/main/templates/main/index.html
+++ b/main/templates/main/index.html
@@ -8,9 +8,9 @@
   <form method="post", action="{% url 'main:process_action' %}">
     {% csrf_token %}
     <a href="{% url 'main:boot_process' %}" class="btn btn-primary">Boot</a>
-    <input type="submit" value="Restart" class="btn btn-success", name="action">
-    <input type="submit" value="Flush" class="btn btn-warning", name="action">
-    <input type="submit" value="Kill" class="btn btn-danger", name="action">
+    <input type="submit" value="Restart" class="btn btn-success", name="action", onclick="return confirm('Restart selected processes?')">
+    <input type="submit" value="Flush" class="btn btn-warning", name="action", onclick="return confirm('Flush selected processes?')">
+    <input type="submit" value="Kill" class="btn btn-danger", name="action", onclick="return confirm('Kill selected processes?')">
     {% render_table table %}
   </form>
 </div>

--- a/main/urls.py
+++ b/main/urls.py
@@ -8,9 +8,7 @@ app_name = "main"
 urlpatterns = [
     path("", views.index, name="index"),
     path("accounts/", include("django.contrib.auth.urls")),
-    path("restart/<uuid:uuid>", views.restart_process, name="restart"),
-    path("kill/<uuid:uuid>", views.kill_process, name="kill"),
-    path("flush/<uuid:uuid>", views.flush_process, name="flush"),
+    path("process_action/", views.process_action, name="process_action"),
     path("logs/<uuid:uuid>", views.logs, name="logs"),
     path("boot_process/", views.BootProcessView.as_view(), name="boot_process"),
 ]

--- a/main/views.py
+++ b/main/views.py
@@ -112,7 +112,7 @@ def process_action(request: HttpRequest) -> HttpResponse:
         HttpResponse redirecting to the index page.
     """
     action = request.POST.get("action")
-    if action is None:
+    if action is None or action.lower() not in ProcessAction:
         return HttpResponseRedirect(reverse("main:index"))
 
     action_enum = ProcessAction(action.lower())

--- a/main/views.py
+++ b/main/views.py
@@ -111,11 +111,12 @@ def process_action(request: HttpRequest) -> HttpResponse:
     Returns:
         HttpResponse redirecting to the index page.
     """
-    action = request.POST.get("action")
-    if action is None or action.lower() not in ProcessAction:
+    try:
+        action = request.POST.get("action", "")
+        action_enum = ProcessAction(action.lower())
+    except ValueError:
         return HttpResponseRedirect(reverse("main:index"))
 
-    action_enum = ProcessAction(action.lower())
     for uuid_ in request.POST.getlist("select"):
         asyncio.run(_process_call(uuid_, action_enum))
     return HttpResponseRedirect(reverse("main:index"))

--- a/main/views.py
+++ b/main/views.py
@@ -100,48 +100,24 @@ async def _process_call(uuid: str, action: ProcessAction) -> None:
 
 
 @login_required
-def restart_process(request: HttpRequest, uuid: uuid.UUID) -> HttpResponse:
-    """Restart the process associated to the given UUID.
+def process_action(request: HttpRequest) -> HttpResponse:
+    """Perform an action on the selected processes.
+
+    Both the action and the selected processes are retrieved from the request.
 
     Args:
-        request: HttpRequest object. This is not used in the function, but is required
-            by Django.
-        uuid: UUID of the process to be restarted.
-
-    Returns:
-        HttpResponse, redirecting to the main page.
-    """
-    asyncio.run(_process_call(str(uuid), ProcessAction.RESTART))
-    return HttpResponseRedirect(reverse("main:index"))
-
-
-@login_required
-def kill_process(request: HttpRequest, uuid: uuid.UUID) -> HttpResponse:
-    """Kill the process associated to the given UUID.
-
-    Args:
-        request: Django HttpRequest object (unused, but required by Django).
-        uuid: UUID of the process to be killed.
+        request: Django HttpRequest object.
 
     Returns:
         HttpResponse redirecting to the index page.
     """
-    asyncio.run(_process_call(str(uuid), ProcessAction.KILL))
-    return HttpResponseRedirect(reverse("main:index"))
+    action = request.POST.get("action")
+    if action is None:
+        return HttpResponseRedirect(reverse("main:index"))
 
-
-@login_required
-def flush_process(request: HttpRequest, uuid: uuid.UUID) -> HttpResponse:
-    """Flush the process associated to the given UUID.
-
-    Args:
-        request: Django HttpRequest object (unused, but required by Django).
-        uuid: UUID of the process to be flushed.
-
-    Returns:
-        HttpResponse redirecting to the index page.
-    """
-    asyncio.run(_process_call(str(uuid), ProcessAction.FLUSH))
+    action_enum = ProcessAction(action.lower())
+    for uuid_ in request.POST.getlist("select"):
+        asyncio.run(_process_call(uuid_, action_enum))
     return HttpResponseRedirect(reverse("main:index"))
 
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -21,27 +21,6 @@ class LoginRequiredTest:
         assertRedirects(response, reverse("main:login") + f"?next={self.endpoint}")
 
 
-class ProcessActionsTest(LoginRequiredTest):
-    """Grouping the tests for the process action views."""
-
-    action: ProcessAction
-
-    @classmethod
-    def setup_class(cls):
-        """Set up the endpoint for the tests."""
-        cls.uuid = uuid4()
-        cls.endpoint = reverse(f"main:{cls.action.value}", kwargs=dict(uuid=cls.uuid))
-
-    def test_process_action_view_authenticated(self, auth_client, mocker):
-        """Test the process action view for an authenticated user."""
-        mock = mocker.patch("main.views._process_call")
-        response = auth_client.get(self.endpoint)
-        assert response.status_code == HTTPStatus.FOUND
-        assert response.url == reverse("main:index")
-
-        mock.assert_called_once_with(str(self.uuid), self.action)
-
-
 class TestIndexView(LoginRequiredTest):
     """Tests for the index view."""
 
@@ -81,22 +60,34 @@ class TestLogsView(LoginRequiredTest):
         assert "log_text" in response.context
 
 
-class TestProcessFlushView(ProcessActionsTest):
-    """Tests for the process flush view."""
+class TestProcessActionView(LoginRequiredTest):
+    """Tests for the process_action view."""
 
-    action = ProcessAction.FLUSH
+    endpoint = reverse("main:process_action")
 
+    def test_process_action_no_action(self, auth_client):
+        """Test process_action view with no action provided."""
+        response = auth_client.post(self.endpoint, data={})
+        assert response.status_code == HTTPStatus.FOUND
+        assert response.url == reverse("main:index")
 
-class TestProcessKillView(ProcessActionsTest):
-    """Tests for the process kill view."""
+    def test_process_action_invalid_action(self, auth_client):
+        """Test process_action view with an invalid action."""
+        response = auth_client.post(self.endpoint, data={"action": "invalid_action"})
+        assert response.status_code == HTTPStatus.FOUND
+        assert response.url == reverse("main:index")
 
-    action = ProcessAction.KILL
+    def test_process_action_valid_action(self, auth_client, mocker):
+        """Test process_action view with a valid action."""
+        mock = mocker.patch("main.views._process_call")
+        uuid_ = str(uuid4())
+        response = auth_client.post(
+            self.endpoint, data={"action": "kill", "select": [uuid_]}
+        )
+        assert response.status_code == HTTPStatus.FOUND
+        assert response.url == reverse("main:index")
 
-
-class TestProcessRestartView(ProcessActionsTest):
-    """Tests for the process restart view."""
-
-    action = ProcessAction.RESTART
+        mock.assert_called_once_with(uuid_, ProcessAction.KILL)
 
 
 class TestBootProcess(LoginRequiredTest):


### PR DESCRIPTION
# Description

This PR remove the per-process operations and add checkboxes and buttons such that the operations can be triggered for multiple processes at once. Asa bonus, the code has been simplified significantly.

Fixes #86 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [x] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
