### PR TITLE
Fix process action form

### DIFF
--- a/main/templates/main/index.html
+++ b/main/templates/main/index.html
@@ -32,8 +32,8 @@
                class="btn btn-danger"
                name="action"
                onclick="return confirm('Kill selected processes?')">
+        {% render_table table %}
       </form>
-      {% render_table table %}
     </div>
     <div class="col">
       <div class="card">


### PR DESCRIPTION
# Description

Somehow in #109 the process data table got moved outside of the form element. This prevented any of the restart/kill/flush buttons from working.

Unfortunately this sort of thing is difficult to catch without writing more involved browser based tests.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
